### PR TITLE
fix: YouTube playlist display issue

### DIFF
--- a/src/components/NowPlaylist.astro
+++ b/src/components/NowPlaylist.astro
@@ -26,7 +26,8 @@ try {
     }
   } else {
     // プロダクション環境：HTTPリクエスト
-    const response = await fetch('/MyPage/data/playlist.json');
+    const baseUrl = import.meta.env.BASE_URL || '';
+    const response = await fetch(`${baseUrl}data/playlist.json`);
     if (response.ok) {
       playlistData = await response.json();
     }
@@ -178,11 +179,11 @@ try {
   }
 </style>
 
-<script>
+<script define:vars={{ baseUrl: import.meta.env.BASE_URL || '' }}>
   // クライアントサイドでプレイリストデータを再取得
   document.addEventListener('DOMContentLoaded', async () => {
     try {
-      const response = await fetch('/MyPage/data/playlist.json');
+      const response = await fetch(`${baseUrl}data/playlist.json`);
       if (response.ok) {
         const data = await response.json();
         // プレイリストが空の場合の処理は既にHTMLに含まれている


### PR DESCRIPTION
Fixes #4

This PR resolves the issue where YouTube songs were not displaying on the published page's home screen.

## Changes
- Updated NowPlaylist component to use Astro's BASE_URL instead of hardcoded paths
- Fixed both server-side and client-side fetch calls
- Ensures proper URL resolution for GitHub Pages deployment

## Testing
The playlist data file exists and contains valid YouTube video data. The component should now properly load and display the playlist on the live site.

Generated with [Claude Code](https://claude.ai/code)