### PR TITLE
Fix navigation links for new domain morumoru.jp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,13 @@ Dark theme with consistent color variables:
 - **Remote**: git@github.com:TsuyoshiUsugi/MyPage.git
 - **Main Branch**: master
 - **Deployment**: Automatic via GitHub Actions to GitHub Pages
+
+## Claude Code Workflow
+When making changes to the codebase, Claude should follow this workflow:
+1. Create a new feature branch for the work
+2. Make necessary code changes
+3. Test the changes (build, type check, etc.)
+4. Create a pull request with descriptive title and summary
+5. Include test plan in the PR description
+
+This ensures proper version control and code review process for all changes.

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -12,7 +12,7 @@ const formattedDate = pubDate.toLocaleDateString('ja-JP');
 ---
 
 <article class="post-card">
-  <a href={`/MyPage/blog/${slug}`} class="post-link">
+  <a href={`/blog/${slug}`} class="post-link">
     <div class="post-content">
       <div class="post-meta">
         <time datetime={pubDate.toISOString()}>{formattedDate}</time>

--- a/src/content/blog/.claude/settings.local.json
+++ b/src/content/blog/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Read(C:\\Users\\qesul\\Documents\\MyPage/**)",
       "Read(C:\\Users\\qesul\\Documents\\MyPage\\src/**)",
       "Read(C:\\Users\\qesul\\Documents\\MyPage/**)",
-      "Bash(npm run build:*)"
+      "Bash(npm run build:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,12 +43,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   <header>
     <nav>
       <div class="nav-container">
-        <a href="/MyPage/" class="logo">モルモ</a>
+        <a href="/" class="logo">モルモ</a>
         <ul class="nav-links">
-          <li><a href="/MyPage/">Home</a></li>
-          <li><a href="/MyPage/blog">Blog</a></li>
-          <li><a href="/MyPage/works">Works</a></li>
-          <li><a href="/MyPage/about">About</a></li>
+          <li><a href="/">Home</a></li>
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="/works">Works</a></li>
+          <li><a href="/about">About</a></li>
         </ul>
       </div>
     </nav>
@@ -62,7 +62,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <div class="footer-container">
       <p>&copy; 2025 モルモ. All rights reserved.</p>
       <nav class="footer-nav">
-        <a href="/MyPage/privacy">Privacy Policy</a>
+        <a href="/privacy">Privacy Policy</a>
       </nav>
     </div>
   </footer>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -30,9 +30,9 @@ const formattedDate = pubDate.toLocaleDateString('ja-JP', {
     <!-- 記事ヘッダー -->
     <header class="post-header">
       <nav class="breadcrumb">
-        <a href="/MyPage/">Home</a>
+        <a href="/">Home</a>
         <span class="separator">›</span>
-        <a href="/MyPage/blog">Blog</a>
+        <a href="/blog">Blog</a>
         <span class="separator">›</span>
         <span class="current">{title}</span>
       </nav>
@@ -69,7 +69,7 @@ const formattedDate = pubDate.toLocaleDateString('ja-JP', {
     <!-- 記事フッター -->
     <footer class="post-footer">
       <div class="post-navigation">
-        <a href="/MyPage/blog" class="back-to-blog">
+        <a href="/blog" class="back-to-blog">
           ← ブログ一覧に戻る
         </a>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,8 +27,8 @@ const latestPosts = allPosts
         技術ブログやプロジェクト、趣味の音楽なども共有しています。
       </p>
       <div class="hero-actions">
-        <a href="/MyPage/about" class="btn-primary">About Me</a>
-        <a href="/MyPage/works" class="btn-secondary">Works</a>
+        <a href="/about" class="btn-primary">About Me</a>
+        <a href="/works" class="btn-secondary">Works</a>
       </div>
     </div>
   </section>
@@ -37,7 +37,7 @@ const latestPosts = allPosts
   <section class="latest-posts">
     <div class="section-header">
       <h2>Latest Posts</h2>
-      <a href="/MyPage/blog" class="view-all">すべて見る →</a>
+      <a href="/blog" class="view-all">すべて見る →</a>
     </div>
     
     {latestPosts.length > 0 ? (
@@ -66,7 +66,7 @@ const latestPosts = allPosts
   <section class="works-preview">
     <div class="section-header">
       <h2>Featured Works</h2>
-      <a href="/MyPage/works" class="view-all">すべて見る →</a>
+      <a href="/works" class="view-all">すべて見る →</a>
     </div>
     
     <div class="works-grid">


### PR DESCRIPTION
## Summary
- Updated all navigation links from `/MyPage/*` to `/*` paths to work with new domain morumoru.jp
- Fixed header navigation (logo, Home, Blog, Works, About links)
- Fixed breadcrumb navigation and back-to-blog links in blog post pages
- Fixed internal page links on home page (About Me, Works buttons and "view all" links)
- Updated footer privacy policy link
- Added Claude Code workflow documentation to CLAUDE.md

## Test plan
- [x] Build passes successfully
- [x] All navigation links updated to use root paths
- [x] Verified all files with `/MyPage/` references have been updated
- [x] Logo click navigates to home page
- [x] Header navigation works for all sections
- [x] Blog post navigation and breadcrumbs work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)