### PR TITLE
Fix YAML syntax error in playlist workflow

### DIFF
--- a/.github/workflows/update-playlist.yml
+++ b/.github/workflows/update-playlist.yml
@@ -142,13 +142,16 @@ jobs:
           # Create PR using GitHub CLI
           gh pr create \
             --title "Update YouTube playlist data [automated]" \
-            --body "This PR updates the YouTube playlist data automatically.
+            --body "$(cat <<'PR_BODY'
+This PR updates the YouTube playlist data automatically.
 
-## Changes
+**Changes**
 - Updated \`public/data/playlist.json\` with latest playlist items
 
-## Auto-merge
-This PR will be automatically merged after creation." \
+**Auto-merge**
+This PR will be automatically merged after creation.
+PR_BODY
+)" \
             --base master \
             --head ${{ steps.set-branch-name.outputs.branch_name }}
       


### PR DESCRIPTION
## Summary
Fix YAML syntax error on line 147 in update-playlist.yml workflow

## Problem
- Markdown headers (`## Changes`) in PR body were interpreted as YAML comments
- Caused Invalid workflow file error
- Prevented RunWorkflow button from appearing

## Solution
- Use heredoc to properly escape PR body content  
- Replace `## Headers` with `**Bold Headers**`
- Ensure YAML syntax is valid

## Test Plan
- [ ] Workflow file validates without errors
- [ ] RunWorkflow button appears in GitHub Actions
- [ ] Manual workflow dispatch works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)