### PR TITLE
Fix playlist display to show actual uploaders

### DIFF
--- a/src/components/NowPlaylist.astro
+++ b/src/components/NowPlaylist.astro
@@ -188,22 +188,29 @@ try {
         
         // プレイリストが取得できた場合、表示を更新
         if (data && data.length > 0) {
+          // HTMLエスケープ関数
+          const escapeHtml = (text) => {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+          };
+          
           const playlistHTML = data.slice(0, 6).map(item => `
             <article class="playlist-item">
-              <a href="https://www.youtube.com/watch?v=${item.videoId}"
+              <a href="https://www.youtube.com/watch?v=${escapeHtml(item.videoId)}"
                  target="_blank"
                  rel="noopener noreferrer"
                  class="playlist-link">
                 <div class="thumbnail">
-                  <img src="${item.thumbnail}" 
-                       alt="${item.title}"
+                  <img src="${escapeHtml(item.thumbnail)}" 
+                       alt="${escapeHtml(item.title)}"
                        loading="lazy"
                        width="320"
                        height="180" />
                 </div>
                 <div class="item-content">
-                  <h3 class="item-title">${item.title}</h3>
-                  <p class="item-channel">${item.channelTitle}</p>
+                  <h3 class="item-title">${escapeHtml(item.title)}</h3>
+                  <p class="item-channel">${escapeHtml(item.channelTitle)}</p>
                 </div>
               </a>
             </article>


### PR DESCRIPTION
## Summary
- Fixed playlist display to show actual music uploaders (artists) instead of playlist owner name
- Improved text rendering with proper HTML escaping for dynamic content
- Enhanced caching behavior for production environment reliability

## Changes Made
- Modified `NowPlaylist.astro` to properly display artist channel names
- Added HTML escaping function for safe dynamic content updates
- Improved client-side playlist data refresh with cache-busting

## Test Plan
- [x] Verify local build completes successfully
- [x] Confirm playlist data structure is correct
- [x] Test HTML escaping prevents display issues
- [ ] Deploy and verify production behavior

🤖 Generated with [Claude Code](https://claude.ai/code)